### PR TITLE
Audio visualizer

### DIFF
--- a/src/sipjs-card.ts
+++ b/src/sipjs-card.ts
@@ -163,6 +163,11 @@ class SipJsCard extends LitElement {
 
         const visualizerContainer = this.renderRoot.querySelector(".visualizer-container");
 
+
+        // MERGE THE MediaElementSource's
+        // https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createChannelMerger
+        // https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode
+
         
         // Create a set of pre-defined bars
         for( let i = 0; i < NBR_OF_BARS; i++ ) {


### PR DESCRIPTION
Add a audio visualizer when video is disabled.

Not working yet, with [captureStream](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/captureStream) the frequencies are still null.
![image](https://user-images.githubusercontent.com/32220029/151721624-f5dbef1e-e05c-4219-92c5-85c40f809060.png)

I was able to make another [MediaStreamAudioSourceNode](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamAudioSourceNode) on the same audioElement, but not sure if it works.