### PR TITLE
Release-audio-resources

### DIFF
--- a/src/sip-core.ts
+++ b/src/sip-core.ts
@@ -371,7 +371,7 @@ export class SIPCore {
         if (this.outgoingAudio) {
             this.outgoingAudio.src = this.config.outgoingRingtoneUrl;
             this.outgoingAudio.play().catch((error) => {
-                console.error("Incoming ringtone failed:", error);
+                console.error("Outgoing ringtone failed:", error);
             });
         }
     }


### PR DESCRIPTION
1. Typescript compilation fix
2. Typo fix in "outgoing ringtone failed"
2. Fix to properly release the media resources for incoming/outgoing ringtones. Without proper removal these continue to capture the current audio stream on iOS, and shows a "Home Assistant" media player on the home screen that simply plays the tone when triggered. With this fix, it defaults to the previously playing media controls (Music, Spotify, ...)