### PR TITLE
feat: update call button color based on SIP registration status

### DIFF
--- a/src/sip-call-dialog.ts
+++ b/src/sip-call-dialog.ts
@@ -195,6 +195,7 @@ class SIPCallDialog extends LitElement {
                 videoElement.pause();
             }
         }
+        this.updateButtonState();
     };
 
     connectedCallback() {
@@ -619,6 +620,25 @@ class SIPCallDialog extends LitElement {
                 console.debug("View changed, setting up button again...");
                 this.setupButton();
             });
+        }
+        this.updateButtonState();
+    }
+
+    private updateButtonState() {
+        const homeAssistant = document.getElementsByTagName("home-assistant")[0];
+        const panel = homeAssistant?.shadowRoot
+            ?.querySelector("home-assistant-main")
+            ?.shadowRoot?.querySelector("ha-panel-lovelace");
+
+        const actionItems = panel?.shadowRoot?.querySelector("hui-root")?.shadowRoot?.querySelector(".action-items");
+        const callButton = actionItems?.querySelector("#sipcore-call-button") as HTMLElement;
+
+        if (callButton) {
+            if (sipCore.registered) {
+                callButton.style.color = "";
+            } else {
+                callButton.style.color = "var(--label-badge-red)";
+            }
         }
     }
 }


### PR DESCRIPTION
Fix: unclear registration status

Problem: Previously, it was difficult to tell if the registration process was complete or if there was an issue unless you open the dialog and click the settings icon.

Solution: The button now defaults to red (indicating an issue/unregistered state) and updates to the theme default only upon correct registration.

Under normal conditions, the correct registration status loads instantly and overrides this with the theme default (making the red invisible). The red state acts as a fallback visual cue that is only exposed if the registration check fails or is incomplete.