### PR TITLE
fix: align ButtonType enum in sip-call-card to use string values

### DIFF
--- a/src/sip-call-card.ts
+++ b/src/sip-call-card.ts
@@ -20,8 +20,8 @@ interface Extension {
 }
 
 enum ButtonType {
-    SERVICE_CALL,
-    DTMF,
+    SERVICE_CALL = "service_call",
+    DTMF = "dtmf",
 }
 
 interface Button {


### PR DESCRIPTION
## Summary

- `sip-call-dialog` uses a **string enum** for `ButtonType` (`"service_call"`, `"dtmf"`);
- `sip-call-card` used a **numeric enum** (`0`, `1`), causing the button type comparison to always fail when the value comes from YAML config (which is always a string);
- Forced to use `type: 0` instead of the documented string values (`type: service_call`).

## Fix

Align `ButtonType` in `sip-call-card.ts` to the same string enum values as `sip-call-dialog.ts`.