### PR TITLE
fix: use config idle_text in sip-call-card placeholder

### DIFF
--- a/src/sip-call-card.ts
+++ b/src/sip-call-card.ts
@@ -255,7 +255,7 @@ class SIPCallCard extends LitElement {
                     sipCore.callState === CALLSTATE.IDLE
                         ? html`
                               <div class="placeholder">
-                                  <span>No active call</span>
+                                  <span>${this.config?.idle_text ?? "No active call"}</span>
                               </div>
                           `
                         : camera


### PR DESCRIPTION
`CallCardConfig` defines a  `idle_text` property which is settable via YAML but the template rendered a hardcoded `"No active call"` string instead of reading the config value.