### PR TITLE
feat: disable answer and end-call buttons when call state is idle

### DIFF
--- a/src/sip-call-card.ts
+++ b/src/sip-call-card.ts
@@ -275,6 +275,7 @@ class SIPCallCard extends LitElement {
                         <ha-icon-button
                             style="color: var(--label-badge-green);"
                             label="Answer call"
+                            ?disabled="${sipCore.callState === CALLSTATE.IDLE}"
                             @click="${() => sipCore.answerCall()}">
                             <ha-icon .icon=${phoneIcon}></ha-icon>
                         </ha-icon-button>
@@ -352,6 +353,7 @@ class SIPCallCard extends LitElement {
                         <ha-icon-button
                             style="color: var(--label-badge-red);"
                             label="End Call"
+                            ?disabled="${sipCore.callState === CALLSTATE.IDLE}"
                             @click="${() => sipCore.endCall()}">
                             <ha-icon .icon=${"mdi:phone-off"}></ha-icon>
                         </ha-icon-button>


### PR DESCRIPTION
The "Answer" and "End Call" buttons in `sip-call-card` were always enabled, even when no call was active, allowing clicks with no effect.

Both buttons now use `?disabled="${sipCore.callState === CALLSTATE.IDLE}"`, consistent with the pattern already used by the mute buttons in the same card.