### PR TITLE
feat: show camera feed in sip-call-card when idle

### DIFF
--- a/src/sip-call-card.ts
+++ b/src/sip-call-card.ts
@@ -35,6 +35,7 @@ interface CallCardConfig {
     buttons: Button[];
     extensions: { [key: string]: Extension };
     idle_text: string;
+    camera_entity: string | null;
     largeUI: boolean;
 }
 
@@ -253,11 +254,21 @@ class SIPCallCard extends LitElement {
                 }" playsinline id="remoteVideo"></video>
                 ${
                     sipCore.callState === CALLSTATE.IDLE
-                        ? html`
-                              <div class="placeholder">
-                                  <span>${this.config?.idle_text ?? "No active call"}</span>
-                              </div>
-                          `
+                        ? this.config?.camera_entity
+                            ? html`
+                                  <hui-image
+                                      tabindex="0"
+                                      .cameraImage=${this.config.camera_entity}
+                                      .hass=${this.hass}
+                                      .cameraView=${"live"}
+                                      .aspectRatio=${"16:9"}
+                                  ></hui-image>
+                              `
+                            : html`
+                                  <div class="placeholder">
+                                      <span>${this.config?.idle_text ?? "No active call"}</span>
+                                  </div>
+                              `
                         : camera
                         ? html`
                               <hui-image


### PR DESCRIPTION
## Summary

Add an optional card-level `camera_entity` property to `sip-call-card` that renders a live camera stream in place of the "No active call" placeholder when no call is active.

Typical use case: a doorbell/intercom setup where the user always wants to see the door camera on the dashboard, even between calls.

## What changed

- `CallCardConfig` interface: added optional `camera_entity: string | null`
- Template IDLE branch: if `camera_entity` is set, renders `<hui-image>` with `cameraView="live"`; otherwise falls back to the existing placeholder
- During a call the existing per-extension camera logic takes over unchanged

## YAML config example

```yaml
type: custom:sip-call-card
camera_entity: camera.front_door
extensions:
  "100":
    name: Doorbell
```