### PR TITLE
Add Call button card

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ It includes official cards and popups, but also supports third-party cards.
 <br>
 <br>
 
+## Call Button Card
+
+`custom:sip-call-button`
+
+A minimal card with a single button for a fixed extension.
+
+- 🟢 Green call button when idle
+- 🔴 Red hangup button while a call is active
+- 🔁 Reflects an ongoing call when you navigate back to the page
+
+```yaml
+type: custom:sip-call-button
+extension: "100"
+name: Doorbell # optional, used for the button label
+```
+
+<br>
+<br>
+
 ## 📋 Requirements
 For this to work you will need the following:
  * ☎️ A sip/pbx server (Works best with the [Asterisk add-on](https://github.com/TECH7Fox/Asterisk-add-on))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "./sip-core";
 import "./sip-call-dialog";
 import "./sip-call-card";
+import "./sip-call-button";
 import "./sip-contacts-card";

--- a/src/sip-call-button.ts
+++ b/src/sip-call-button.ts
@@ -42,6 +42,7 @@ class SIPCallButtonCard extends LitElement {
         return css`
             ha-card {
                 display: flex;
+                flex-direction: column;
                 align-items: center;
                 justify-content: center;
                 padding: 8px;
@@ -61,6 +62,28 @@ class SIPCallButtonCard extends LitElement {
 
             .hangup {
                 color: var(--label-badge-red);
+            }
+
+            /* Smaller than the call/hangup button */
+            .mute {
+                color: var(--secondary-text-color);
+                --mdc-icon-button-size: 40px;
+                --mdc-icon-size: 24px;
+            }
+
+            /* Blink/pulse the card background while the phone is ringing */
+            ha-card.ringing {
+                animation: ringing-pulse 1s ease-in-out infinite;
+            }
+
+            @keyframes ringing-pulse {
+                0%,
+                100% {
+                    background-color: var(--card-background-color);
+                }
+                50% {
+                    background-color: var(--label-badge-green);
+                }
             }
         `;
     }
@@ -82,10 +105,15 @@ class SIPCallButtonCard extends LitElement {
     render() {
         // The call state lives in the global sipCore singleton, so an ongoing
         // call is still reflected here after navigating away and back.
-        const isIdle = sipCore.callState === CALLSTATE.IDLE;
+        const callState = sipCore.callState;
+        const isIdle = callState === CALLSTATE.IDLE;
+        // The phone is "ringing" while a call is being established (incoming or
+        // outgoing ringback), but not once it is connected.
+        const isRinging = callState === CALLSTATE.INCOMING || callState === CALLSTATE.OUTGOING;
+        const isMuted = sipCore.RTCSession?.isMuted().audio ?? false;
 
         return html`
-            <ha-card>
+            <ha-card class="${isRinging ? "ringing" : ""}">
                 ${isIdle
                     ? html`
                           <ha-icon-button
@@ -103,6 +131,18 @@ class SIPCallButtonCard extends LitElement {
                               @click="${() => sipCore.endCall()}"
                           >
                               <ha-icon .icon=${"mdi:phone-off"}></ha-icon>
+                          </ha-icon-button>
+                          <ha-icon-button
+                              class="mute"
+                              label="${isMuted ? "Unmute" : "Mute"}"
+                              ?disabled="${sipCore.RTCSession === null}"
+                              @click="${() => {
+                                  if (isMuted) sipCore.RTCSession?.unmute({ audio: true });
+                                  else sipCore.RTCSession?.mute({ audio: true });
+                                  this.requestUpdate();
+                              }}"
+                          >
+                              <ha-icon .icon=${isMuted ? "mdi:microphone-off" : "mdi:microphone"}></ha-icon>
                           </ha-icon-button>
                       `}
             </ha-card>

--- a/src/sip-call-button.ts
+++ b/src/sip-call-button.ts
@@ -113,6 +113,7 @@ class SIPCallButtonCard extends LitElement {
         // call is still reflected here after navigating away and back.
         const callState = sipCore.callState;
         const isIdle = callState === CALLSTATE.IDLE;
+        const isConnected = callState === CALLSTATE.CONNECTED;
         // The phone is "ringing" while a call is being established (incoming or
         // outgoing ringback), but not once it is connected.
         const isRinging = callState === CALLSTATE.INCOMING || callState === CALLSTATE.OUTGOING;
@@ -128,6 +129,16 @@ class SIPCallButtonCard extends LitElement {
                               @click="${() => sipCore.startCall(this.config?.extension || "")}"
                           >
                               <ha-icon .icon=${"mdi:phone"}></ha-icon>
+                          </ha-icon-button>
+                      `
+                    : !isConnected
+                    ? html`
+                          <ha-icon-button
+                              class="hangup"
+                              label="End call"
+                              @click="${() => sipCore.endCall()}"
+                          >
+                              <ha-icon .icon=${"mdi:phone-settings"}></ha-icon>
                           </ha-icon-button>
                       `
                     : html`

--- a/src/sip-call-button.ts
+++ b/src/sip-call-button.ts
@@ -1,0 +1,119 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { sipCore, CALLSTATE } from "./sip-core";
+
+declare global {
+    interface Window {
+        customCards?: Array<{ type: string; name: string; preview: boolean; description: string }>;
+    }
+}
+
+interface CallButtonCardConfig {
+    extension: string;
+    name: string;
+}
+
+@customElement("sip-call-button")
+class SIPCallButtonCard extends LitElement {
+    @property()
+    public hass = sipCore.hass;
+
+    @property()
+    public config: CallButtonCardConfig | undefined;
+
+    setConfig(config: any) {
+        if (!config.extension) {
+            throw new Error("You need to define an extension to call");
+        }
+        this.config = config;
+    }
+
+    static getStubConfig() {
+        return {
+            extension: "100",
+        };
+    }
+
+    getCardSize() {
+        return 1;
+    }
+
+    static get styles() {
+        return css`
+            ha-card {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 8px;
+                --mdc-icon-button-size: 64px;
+                --mdc-icon-size: 40px;
+            }
+
+            ha-icon {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+
+            .call {
+                color: var(--label-badge-green);
+            }
+
+            .hangup {
+                color: var(--label-badge-red);
+            }
+        `;
+    }
+
+    updateHandler = () => {
+        this.requestUpdate();
+    };
+
+    connectedCallback() {
+        super.connectedCallback();
+        window.addEventListener("sipcore-update", this.updateHandler);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        window.removeEventListener("sipcore-update", this.updateHandler);
+    }
+
+    render() {
+        // The call state lives in the global sipCore singleton, so an ongoing
+        // call is still reflected here after navigating away and back.
+        const isIdle = sipCore.callState === CALLSTATE.IDLE;
+
+        return html`
+            <ha-card>
+                ${isIdle
+                    ? html`
+                          <ha-icon-button
+                              class="call"
+                              label="Call ${this.config?.name || this.config?.extension}"
+                              @click="${() => sipCore.startCall(this.config?.extension || "")}"
+                          >
+                              <ha-icon .icon=${"mdi:phone"}></ha-icon>
+                          </ha-icon-button>
+                      `
+                    : html`
+                          <ha-icon-button
+                              class="hangup"
+                              label="End call"
+                              @click="${() => sipCore.endCall()}"
+                          >
+                              <ha-icon .icon=${"mdi:phone-off"}></ha-icon>
+                          </ha-icon-button>
+                      `}
+            </ha-card>
+        `;
+    }
+}
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: "sip-call-button",
+    name: "SIP Call Button Card",
+    preview: true,
+    description: "A simple call/hangup button for a single extension",
+});

--- a/src/sip-call-button.ts
+++ b/src/sip-call-button.ts
@@ -50,6 +50,10 @@ class SIPCallButtonCard extends LitElement {
                 --mdc-icon-size: 40px;
             }
 
+            ha-card.fill-container {
+                height: 100%;
+            }
+
             ha-icon {
                 display: flex;
                 align-items: center;
@@ -73,16 +77,18 @@ class SIPCallButtonCard extends LitElement {
 
             /* Blink/pulse the card background while the phone is ringing */
             ha-card.ringing {
-                animation: ringing-pulse 1s ease-in-out infinite;
+                animation: ringing-pulse 2s infinite;
             }
 
             @keyframes ringing-pulse {
-                0%,
-                100% {
-                    background-color: var(--card-background-color);
+                0% {
+                    box-shadow: inset 0 0 0 0 rgb(0, 160, 0);
                 }
                 50% {
-                    background-color: var(--label-badge-green);
+                    box-shadow: inset 0 0 10px 5px rgb(0, 160, 0);
+                }
+                100% {
+                    box-shadow: inset 0 0 0 0 rgb(0, 160, 0);
                 }
             }
         `;
@@ -113,7 +119,7 @@ class SIPCallButtonCard extends LitElement {
         const isMuted = sipCore.RTCSession?.isMuted().audio ?? false;
 
         return html`
-            <ha-card class="${isRinging ? "ringing" : ""}">
+            <ha-card class="${isRinging ? "ringing" : ""} fill-container">
                 ${isIdle
                     ? html`
                           <ha-icon-button


### PR DESCRIPTION
Create a new widget for call/hangup specific extension. This is usefull to manage doorbels, you can have the camera view in one widget and the call/hangup button in another.

The box card show a pulse inner shadow while calling.

Call status: IDLE

<img width="1002" height="418" alt="image" src="https://github.com/user-attachments/assets/60a541f5-3ac5-41f2-9b84-7d75955b9f0d" />

Call status: CONNECTING

<img width="1002" height="418" alt="image" src="https://github.com/user-attachments/assets/ffedaa3a-895d-4dfc-a862-ef674452dd81" />

Call status: CONNECTED

<img width="1002" height="484" alt="image" src="https://github.com/user-attachments/assets/e39b0ce8-0bd8-4e5c-a96b-e5e3a5963122" />
