### PR TITLE
Reconnect the UA after the tab/screen was hidden and comes back

### DIFF
--- a/src/sip-core.ts
+++ b/src/sip-core.ts
@@ -97,6 +97,7 @@ export class SIPCore {
 
     private wssUrl!: string;
     private iceCandidateTimeout: ReturnType<typeof setTimeout> | null = null;
+    private visibilityRecoveryTimeout: ReturnType<typeof setTimeout> | null = null;
 
     public remoteAudioStream: MediaStream | null = null;
     public remoteVideoStream: MediaStream | null = null;
@@ -269,6 +270,37 @@ export class SIPCore {
         }
     }
 
+    /**
+     * Browsers suspend a hidden tab's JS timers (including the UA's own
+     * heartbeat/registration-retry timers), which can leave the WebSocket
+     * silently dead by the time the tab becomes visible again - most
+     * noticeable on an always-on kiosk display whose screen turns off on a
+     * timer. Neither `registered`/`unregistered`/`registrationFailed` fire in
+     * that case, since nothing ever told the UA the transport failed. Watch
+     * for the page becoming visible again and, if the UA still isn't
+     * registered a few seconds later (and no call is in progress), restart
+     * it explicitly rather than leaving the client silently unreachable
+     * until something else notices.
+     */
+    private setupVisibilityRecovery() {
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState !== "visible") return;
+            if (this.visibilityRecoveryTimeout != null) {
+                clearTimeout(this.visibilityRecoveryTimeout);
+            }
+            this.visibilityRecoveryTimeout = setTimeout(() => {
+                this.visibilityRecoveryTimeout = null;
+                if (document.visibilityState !== "visible") return;
+                if (this.registered) return;
+                if (this.callState !== CALLSTATE.IDLE) return; // never interrupt an active call
+                console.warn("SIP Core: still unregistered after becoming visible again, reconnecting...");
+                this.ua.stop();
+                this.ua = this.setupUA();
+                this.ua.start();
+            }, 4000);
+        });
+    }
+
     private startCallTimer() {
         this.callTimerHandle = setInterval(() => {
             this.triggerUpdate();
@@ -305,6 +337,7 @@ export class SIPCore {
 
         console.debug(`Connecting to ${this.wssUrl}...`);
         this.ua.start();
+        this.setupVisibilityRecovery();
         if (this.config.popup_config !== null) {
             this.setupPopup();
         }


### PR DESCRIPTION
## What

Adds a `visibilitychange` listener in `SIPCore.init()`: when the page becomes visible again and the UA still isn't registered a few seconds later (and no call is in progress), it explicitly restarts the UA (`ua.stop()` → rebuild → `ua.start()`).

## Why

Browsers suspend a hidden tab's JS timers, which can silently kill the WebSocket registration on any always-on/kiosk-style deployment - a wall-mounted tablet whose screen turns off on a timer being the obvious case. While the tab is hidden, neither the UA's own heartbeat `setInterval` nor its `registrationFailed` retry `setTimeout` get a chance to run, so by the time the screen wakes back up the connection is already dead - and since nothing ever fired a `registrationFailed`/`unregistered` event (the transport just silently stopped ticking), there's currently no path back to a working state short of a manual page reload.

Reproduced this directly on a kiosk tablet running a `custom:sip-call-card` dashboard: turning the screen back on alone did **not** bring registration back - waited 40+ seconds with the screen genuinely on, confirmed via the Asterisk server's own logs that the endpoint stayed `Unreachable` the whole time, zero reconnect attempts logged. Only a full page reload re-established it.

Since forcing the screen to stay always-on isn't a realistic fix for a wall display (and fights against the user's own screen-timeout preference), this patches it from the other end: watch for the page becoming visible again, give the connection a few seconds in case it recovers on its own, and explicitly restart the UA if it's still down. Skipped entirely whenever a call is in progress, so it can never interrupt an active call, and it's a no-op on the common case where registration is already fine.

## Testing

- `npx tsc --noEmit` - no new errors (the two pre-existing `jssip` type-declaration errors are present identically on `main`, unrelated to this change).
- `npm run build` - compiles clean, confirmed the new code is present in the emitted bundle.
- Live-tested end to end on a real kiosk tablet against a real Asterisk/PJSIP backend: put the screen to sleep, confirmed the endpoint went `Unreachable` in the PBX logs, woke the screen, confirmed (via the same logs) the endpoint came back `Reachable` within seconds without a manual reload.