### PR TITLE
Add go2rtc Ingress camera support to SIP call popup

### DIFF
--- a/src/sip-call-dialog.ts
+++ b/src/sip-call-dialog.ts
@@ -282,6 +282,9 @@ class SIPCallDialog extends LitElement {
     closePopup() {
         this.open = false;
         this.stopCameraRefresh();
+        this.go2rtcIngressKey = "";
+        this.go2rtcIngressFrameUrl = "";
+        this.go2rtcIngressFailed = false;
         this.requestUpdate();
     }
 

--- a/src/sip-call-dialog.ts
+++ b/src/sip-call-dialog.ts
@@ -7,6 +7,13 @@ interface Extension {
     name: string;
     extension: string;
     camera_entity: string | null;
+    stream_name?: string | null;
+    go2rtc_stream?: string | null;
+    go2rtc_url?: string | null;
+    go2rtc_stream_url?: string | null;
+    go2rtc_ingress?: boolean | null;
+    go2rtc_addon_slug?: string | null;
+    live_provider?: string | null;
 }
 
 enum ButtonType {
@@ -57,6 +64,22 @@ class SIPCallDialog extends LitElement {
 
     @state()
     private currentCamera: string = "";
+
+    @state()
+    private cameraImageCacheBuster = Date.now();
+
+    @state()
+    private cameraStreamFailed = false;
+
+    @state()
+    private go2rtcIngressFrameUrl = "";
+
+    @state()
+    private go2rtcIngressFailed = false;
+
+    private go2rtcIngressKey = "";
+
+    private cameraRefreshInterval: number | undefined;
 
     constructor() {
         super();
@@ -117,15 +140,27 @@ class SIPCallDialog extends LitElement {
                 display: block;
             }
 
-            webrtc-camera {
-                height: 100%;
+            hui-image {
                 width: 100%;
                 display: block;
             }
 
-            webrtc-camera video {
+            .sip-camera-image {
+                display: block;
                 width: 100%;
                 height: 100%;
+                object-fit: contain;
+                background: #000;
+            }
+
+            .sip-camera-frame {
+                display: block;
+                width: 100%;
+                height: 100%;
+                min-height: 320px;
+                border: 0;
+                background: #000;
+                overflow: hidden;
             }
 
             #remoteVideo {
@@ -210,30 +245,7 @@ class SIPCallDialog extends LitElement {
             }
         }
         this.updateButtonState();
-        this.updateWebRTCCamera();
     };
-
-    updateWebRTCCamera() {
-        const element = this.renderRoot.querySelector('webrtc-camera') as any;
-        if (element && this.currentCamera) {
-            if (!element.config || element.config.entity !== this.currentCamera) {
-                element.setConfig({
-                    entity: this.currentCamera,
-                    muted: true,
-                    ui: false, // Disable custom UI buttons
-                });
-                element.hass = this.hass;
-                // Disable native video controls
-                if (element.video) {
-                    element.video.controls = false;
-                }
-                // Trigger connection
-                if (element.onconnect) {
-                    element.onconnect();
-                }
-            }
-        }
-    }
 
     connectedCallback() {
         super.connectedCallback();
@@ -251,6 +263,7 @@ class SIPCallDialog extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
         window.removeEventListener("sipcore-update", this.updateHandler);
+        this.stopCameraRefresh();
 
         if (this.config.auto_open !== false) {
             window.removeEventListener("sipcore-call-started", this.openPopup);
@@ -268,36 +281,244 @@ class SIPCallDialog extends LitElement {
 
     closePopup() {
         this.open = false;
+        this.stopCameraRefresh();
         this.requestUpdate();
     }
 
-    renderCameraStream(camera: string) {
-        // Store camera for updates
-        this.currentCamera = camera;
+    private ensureCameraRefresh(camera: string) {
+        if (this.currentCamera !== camera) {
+            this.currentCamera = camera;
+            this.cameraImageCacheBuster = Date.now();
+        }
 
-        // Check if WebRTC Camera component is available for low-latency streaming
-        const hasWebRTC = customElements.get('webrtc-camera');
+        if (this.cameraRefreshInterval !== undefined) return;
 
-        if (hasWebRTC) {
-            // Use WebRTC for low-latency streaming
-            // Schedule configuration after render
-            requestAnimationFrame(() => this.updateWebRTCCamera());
+        this.cameraRefreshInterval = window.setInterval(() => {
+            if (!this.open || !this.currentCamera || sipCore.callState === CALLSTATE.IDLE) {
+                this.stopCameraRefresh();
+                return;
+            }
 
-            return html`<webrtc-camera></webrtc-camera>`;
-        } else {
-            // Fall back to standard Home Assistant camera stream (higher latency)
-            return html`
-                <ha-camera-stream
-                    allow-exoplayer
-                    muted
-                    .hass=${this.hass}
-                    .stateObj=${this.hass.states[camera]}
-                ></ha-camera-stream>
-            `;
+            this.cameraImageCacheBuster = Date.now();
+            this.requestUpdate();
+        }, 1000);
+    }
+
+    private stopCameraRefresh() {
+        if (this.cameraRefreshInterval === undefined) return;
+
+        window.clearInterval(this.cameraRefreshInterval);
+        this.cameraRefreshInterval = undefined;
+    }
+
+    private getCameraImageUrl(camera: string) {
+        const stateObj = this.hass?.states?.[camera];
+        const entityPicture = stateObj?.attributes?.entity_picture as string | undefined;
+        const accessToken = stateObj?.attributes?.access_token as string | undefined;
+        const baseUrl = entityPicture || `/api/camera_proxy/${camera}${accessToken ? `?token=${accessToken}` : ""}`;
+        const separator = baseUrl.includes("?") ? "&" : "?";
+
+        return `${baseUrl}${separator}sipcore_ts=${this.cameraImageCacheBuster}`;
+    }
+
+    private getGo2RTCFrameUrl(extension?: Extension) {
+        const streamName = extension?.stream_name || extension?.go2rtc_stream || "";
+        const configuredUrl = extension?.go2rtc_stream_url || extension?.go2rtc_url || "";
+        if (!streamName || !configuredUrl) return "";
+
+        let url = configuredUrl.trim();
+        if (!url) return "";
+
+        if (url.includes("/api/homekit")) {
+            url = url.split("/api/homekit")[0];
+        } else if (url.includes("/api/webtorrent")) {
+            url = url.split("/api/webtorrent")[0];
+        }
+
+        if (!url.includes("stream.html")) {
+            url = `${url.replace(/\/$/, "")}/stream.html`;
+        }
+
+        const separator = url.includes("?") ? "&" : "?";
+        const mode = extension?.live_provider === "webrtc" ? "webrtc" : "mse";
+
+        return `${url}${separator}src=${encodeURIComponent(streamName)}&mode=${encodeURIComponent(mode)}&width=100%`;
+    }
+
+    private async ensureGo2RTCIngressFrameUrl(extension?: Extension) {
+        const streamName = extension?.stream_name || extension?.go2rtc_stream || "";
+        if (!this.hass || !streamName || !extension?.go2rtc_ingress) return;
+
+        const mode = extension?.live_provider === "webrtc" ? "webrtc" : "mse";
+        const key = `${streamName}|${mode}`;
+        if (this.go2rtcIngressKey === key && (this.go2rtcIngressFrameUrl || this.go2rtcIngressFailed)) return;
+
+        this.go2rtcIngressKey = key;
+        this.go2rtcIngressFrameUrl = "";
+        this.go2rtcIngressFailed = false;
+
+        try {
+            const sessionResult = await this.hass.callWS({
+                type: "supervisor/api",
+                endpoint: "/ingress/session",
+                method: "post",
+            });
+
+            const session = sessionResult?.session;
+            if (!session) throw new Error("Supervisor did not return an ingress session");
+
+            document.cookie =
+                `ingress_session=${session}; path=/; SameSite=Lax` +
+                (window.location.protocol === "https:" ? "; Secure" : "");
+
+            let ingressUrl = extension?.go2rtc_stream_url || extension?.go2rtc_url || "";
+
+            if (!ingressUrl) {
+                const configuredSlug = extension?.go2rtc_addon_slug || "";
+                let addonInfo: any = undefined;
+
+                if (configuredSlug) {
+                    try {
+                        addonInfo = await this.hass.callWS({
+                            type: "supervisor/api",
+                            endpoint: `/addons/${configuredSlug}/info`,
+                            method: "get",
+                        });
+                    } catch (err) {
+                        console.warn(`SIP-Core go2rtc add-on slug ${configuredSlug} failed, trying auto-discovery`, err);
+                    }
+                }
+
+                if (!addonInfo) {
+                    const addonsResult = await this.hass.callWS({
+                        type: "supervisor/api",
+                        endpoint: "/addons",
+                        method: "get",
+                    });
+
+                    const addons = addonsResult?.addons || [];
+                    const go2rtcAddon = addons.find((addon: any) => {
+                        const slug = String(addon?.slug || "").toLowerCase();
+                        const name = String(addon?.name || "").toLowerCase();
+                        return slug.includes("go2rtc") || name.includes("go2rtc");
+                    });
+
+                    if (go2rtcAddon?.slug) {
+                        addonInfo = await this.hass.callWS({
+                            type: "supervisor/api",
+                            endpoint: `/addons/${go2rtcAddon.slug}/info`,
+                            method: "get",
+                        });
+                    }
+                }
+
+                ingressUrl = addonInfo?.ingress_url || addonInfo?.ingress_entry || "";
+            }
+
+            if (!ingressUrl) {
+                throw new Error("No go2rtc ingress URL available. Configure go2rtc_addon_slug or go2rtc_url.");
+            }
+
+            let url = ingressUrl.trim();
+            if (url.includes("/api/homekit")) {
+                url = url.split("/api/homekit")[0];
+            } else if (url.includes("/api/webtorrent")) {
+                url = url.split("/api/webtorrent")[0];
+            }
+
+            if (!url.includes("stream.html")) {
+                url = `${url.replace(/\/$/, "")}/stream.html`;
+            }
+
+            const separator = url.includes("?") ? "&" : "?";
+
+            if (this.go2rtcIngressKey === key) {
+                this.go2rtcIngressFrameUrl = `${url}${separator}` +
+                    `src=${encodeURIComponent(streamName)}` +
+                    `&mode=${encodeURIComponent(mode)}` +
+                    `&width=100%`;
+                this.requestUpdate();
+            }
+        } catch (err) {
+            console.warn("SIP-Core could not create go2rtc Ingress session, falling back", err);
+            if (this.go2rtcIngressKey === key) {
+                this.go2rtcIngressFailed = true;
+                this.requestUpdate();
+            }
         }
     }
 
+    renderCameraStream(camera: string) {
+        this.hass = sipCore.hass || this.hass;
+
+        if (this.currentCamera !== camera) {
+            this.currentCamera = camera;
+            this.cameraStreamFailed = false;
+            this.go2rtcIngressKey = "";
+            this.go2rtcIngressFrameUrl = "";
+            this.go2rtcIngressFailed = false;
+            this.cameraImageCacheBuster = Date.now();
+        }
+
+        if (!this.hass?.states?.[camera]) {
+            console.warn(`Camera entity ${camera} was not found, cannot render SIP call camera stream.`);
+            return html``;
+        }
+
+        const extension = this.config.extensions[sipCore.remoteExtension || ""];
+        const streamName = extension?.stream_name || extension?.go2rtc_stream || "";
+        const go2rtcFrameUrl = this.getGo2RTCFrameUrl(extension);
+
+        if (extension?.go2rtc_ingress && streamName && !this.go2rtcIngressFailed) {
+            this.stopCameraRefresh();
+            this.ensureGo2RTCIngressFrameUrl(extension);
+
+            if (this.go2rtcIngressFrameUrl) {
+                return html`
+                    <iframe
+                        class="sip-camera-frame"
+                        src=${this.go2rtcIngressFrameUrl}
+                        allow="autoplay; fullscreen; microphone; camera"
+                    ></iframe>
+                `;
+            }
+
+            return html`
+                <img
+                    class="sip-camera-image"
+                    alt=""
+                    src=${this.getCameraImageUrl(camera)}
+                />
+            `;
+        }
+
+        if (go2rtcFrameUrl) {
+            this.stopCameraRefresh();
+
+            return html`
+                <iframe
+                    class="sip-camera-frame"
+                    src=${go2rtcFrameUrl}
+                    allow="autoplay; fullscreen; microphone; camera"
+                ></iframe>
+            `;
+        }
+
+        this.ensureCameraRefresh(camera);
+
+        return html`
+            <img
+                class="sip-camera-image"
+                alt=""
+                src=${this.getCameraImageUrl(camera)}
+            />
+        `;
+    }
+
     render() {
+        this.hass = sipCore.hass || this.hass;
+        this.config = (sipCore.config?.popup_config || this.config) as PopupConfig;
+
         let camera: string = "";
         let statusText;
         let phoneIcon: string;


### PR DESCRIPTION
## Summary

Adds optional go2rtc Ingress support for camera previews in the SIP call popup.

When an extension is configured with `go2rtc_ingress: true`, the call dialog creates a Home Assistant Ingress session, discovers the go2rtc add-on Ingress URL, and renders the go2rtc `stream.html` viewer inside the SIP popup.

This allows low-latency go2rtc streams to work through Home Assistant Ingress without exposing go2rtc ports directly.

## Motivation

The existing camera rendering path may fall back to snapshots, which can be delayed and may not provide a usable live preview for doorbell/intercom use cases.

go2rtc already supports live viewing through Home Assistant Ingress. This PR allows SIP-Core popup camera previews to use that same path.

## Configuration Example

```yaml
popup_config:
  extensions:
    '1002':
      camera_entity: camera.127_0_0_1
      stream_name: verso_doorbell
      go2rtc_ingress: true
      name: Porta Alameda
```

Optional explicit add-on slug:

```yaml
go2rtc_addon_slug: local_go2rtc
```

Optional explicit go2rtc Ingress/base URL:

```yaml
go2rtc_url: /api/hassio_ingress/...
```

## Behavior

- Creates a Supervisor Ingress session.
- Sets the `ingress_session` cookie.
- Auto-discovers the go2rtc add-on by name/slug.
- Renders `stream.html?src=<stream_name>&mode=mse`.
- Falls back to the existing snapshot preview if Ingress cannot be used.

## Testing

Tested with:

- SIP incoming call popup.
- `popup_config.extensions['1002']`.
- go2rtc stream `verso_doorbell`.
- Home Assistant remote access through HTTPS.
- No direct go2rtc port forwarding.
